### PR TITLE
fixed dockerfile

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8
+FROM openjdk:8
 
 COPY . /webpush-server
 


### PR DESCRIPTION
The base image extended by the dockerfile wasn't found while building the docker image, so I changed it with an equivalent one.  